### PR TITLE
fix: crash when location contains commas

### DIFF
--- a/app/src/main/java/moe/fuqiuluo/portal/ui/mock/HistoricalLocation.kt
+++ b/app/src/main/java/moe/fuqiuluo/portal/ui/mock/HistoricalLocation.kt
@@ -9,17 +9,52 @@ data class HistoricalLocation(
     val lon: Double
 ) {
     companion object {
-        // $name,$address,${newLat},${newLon}
+        // Format: "name","address","lat","lon"
         fun fromString(str: String): HistoricalLocation {
-            val parts = str.split(",")
-            if (parts.size != 4) {
-                throw IllegalArgumentException("Invalid string: $str")
+            // CSV parser supporting commas inside quoted fields
+            val fields = mutableListOf<String>()
+            var currentField = StringBuilder()
+            var inQuotes = false
+            
+            var i = 0
+            while (i < str.length) {
+                val char = str[i]
+                when {
+                    char == '"' && (i + 1 >= str.length || str[i + 1] != '"') -> {
+                        // Toggle quote state
+                        inQuotes = !inQuotes
+                    }
+                    char == '"' && i + 1 < str.length && str[i + 1] == '"' -> {
+                        // Handle escaped quotes ("") 
+                        currentField.append('"')
+                        // Skip next quote
+                        i++
+                    }
+                    char == ',' && !inQuotes -> {
+                        // Comma as separator
+                        fields.add(currentField.toString().trim())
+                        currentField = StringBuilder()
+                    }
+                    else -> {
+                        // Regular character
+                        currentField.append(char)
+                    }
+                }
+                i++
             }
+            
+            // Add the last field
+            fields.add(currentField.toString().trim())
+            
+            if (fields.size != 4) {
+                throw IllegalArgumentException("Invalid format. Expected 4 fields but got ${fields.size}: $str")
+            }
+            
             return HistoricalLocation(
-                parts[0],
-                parts[1],
-                parts[2].toDouble(),
-                parts[3].toDouble()
+                name = fields[0].trim('"'),
+                address = fields[1].trim('"'),
+                lat = fields[2].trim('"').toDouble(),
+                lon = fields[3].trim('"').toDouble()
             )
         }
     }
@@ -27,6 +62,11 @@ data class HistoricalLocation(
     override fun toString(): String {
         val plainLat = BigDecimal(lat).toPlainString()
         val plainLon = BigDecimal(lon).toPlainString()
-        return "$name,$address,$plainLat,$plainLon"
+        
+        // Quote fields containing commas
+        val quotedName = if (name.contains(",")) "\"$name\"" else name
+        val quotedAddress = if (address.contains(",")) "\"$address\"" else address
+        
+        return "$quotedName,$quotedAddress,$plainLat,$plainLon"
     }
 }


### PR DESCRIPTION
This PR addresses a critical bug in the location data parsing logic where the original implementation used a simple split(",") method. This approach failed when address fields contained commas (e.g., "New York, 12 Canal St, NY 10002"), resulting in malformed data and runtime exceptions.

## Problem
The naive split logic caused parsing errors for valid input strings containing commas within address fields. Specifically, it resulted in more than the expected number of fields (>4), triggering an Invalid string exception. This made the system fragile and incapable of processing common real-world address formats.