### PR TITLE
refactor: use json instead of csv to store location history

### DIFF
--- a/app/src/main/java/moe/fuqiuluo/portal/ui/mock/HistoricalLocation.kt
+++ b/app/src/main/java/moe/fuqiuluo/portal/ui/mock/HistoricalLocation.kt
@@ -1,6 +1,7 @@
 package moe.fuqiuluo.portal.ui.mock
 
-import java.math.BigDecimal
+import com.alibaba.fastjson2.JSON
+import com.alibaba.fastjson2.JSONObject
 
 data class HistoricalLocation(
     val name: String,
@@ -9,64 +10,52 @@ data class HistoricalLocation(
     val lon: Double
 ) {
     companion object {
-        // Format: "name","address","lat","lon"
         fun fromString(str: String): HistoricalLocation {
-            // CSV parser supporting commas inside quoted fields
+            // Try to parse as JSON
+            return try {
+                JSON.parseObject(str, HistoricalLocation::class.java)
+            } catch (e: Exception) {
+                // Fallback to legacy CSV format for backward compatibility
+                parseFromLegacyCsv(str)
+            }
+        }
+
+        // Legacy CSV parser for backward compatibility
+        private fun parseFromLegacyCsv(str: String): HistoricalLocation {
             val fields = mutableListOf<String>()
             var currentField = StringBuilder()
             var inQuotes = false
-            
             var i = 0
             while (i < str.length) {
                 val char = str[i]
                 when {
-                    char == '"' && (i + 1 >= str.length || str[i + 1] != '"') -> {
-                        // Toggle quote state
-                        inQuotes = !inQuotes
-                    }
+                    char == '"' && (i + 1 >= str.length || str[i + 1] != '"') -> inQuotes = !inQuotes
                     char == '"' && i + 1 < str.length && str[i + 1] == '"' -> {
-                        // Handle escaped quotes ("") 
-                        currentField.append('"')
-                        // Skip next quote
-                        i++
+                        currentField.append('"'); i++
                     }
                     char == ',' && !inQuotes -> {
-                        // Comma as separator
                         fields.add(currentField.toString().trim())
                         currentField = StringBuilder()
                     }
-                    else -> {
-                        // Regular character
-                        currentField.append(char)
-                    }
+                    else -> currentField.append(char)
                 }
                 i++
             }
-            
-            // Add the last field
             fields.add(currentField.toString().trim())
-            
-            if (fields.size != 4) {
-                throw IllegalArgumentException("Invalid format. Expected 4 fields but got ${fields.size}: $str")
-            }
-            
-            return HistoricalLocation(
-                name = fields[0].trim('"'),
-                address = fields[1].trim('"'),
-                lat = fields[2].trim('"').toDouble(),
-                lon = fields[3].trim('"').toDouble()
-            )
+
+            if (fields.size < 4) throw IllegalArgumentException("Invalid CSV: $str")
+
+            val latStr = fields[fields.size - 2].trim('"')
+            val lonStr = fields[fields.size - 1].trim('"')
+            val name = fields.first().trim('"')
+            val address = fields.subList(1, fields.size - 2)
+                .joinToString(",") { it.trim('"') }
+
+            return HistoricalLocation(name, address, latStr.toDouble(), lonStr.toDouble())
         }
     }
 
     override fun toString(): String {
-        val plainLat = BigDecimal(lat).toPlainString()
-        val plainLon = BigDecimal(lon).toPlainString()
-        
-        // Quote fields containing commas
-        val quotedName = if (name.contains(",")) "\"$name\"" else name
-        val quotedAddress = if (address.contains(",")) "\"$address\"" else address
-        
-        return "$quotedName,$quotedAddress,$plainLat,$plainLon"
+        return JSON.toJSONString(this)
     }
 }

--- a/app/src/main/java/moe/fuqiuluo/portal/ui/mock/HistoricalLocationAdapter.kt
+++ b/app/src/main/java/moe/fuqiuluo/portal/ui/mock/HistoricalLocationAdapter.kt
@@ -107,4 +107,28 @@ class HistoricalLocationAdapter(
             true
         }
     }
+
+    // Get all location items in the adapter
+    fun getAllItems(): List<HistoricalLocation> {
+        return dataSet.toList()
+    }
+
+    // Reset adapter data with new locations
+    fun resetData(newData: List<HistoricalLocation>) {
+        dataSet.clear()
+        dataSet.addAll(newData)
+        notifyDataSetChanged()
+    }
+    
+    // Update existing location or add new one
+    fun updateOrAddItem(location: HistoricalLocation) {
+        val index = dataSet.indexOfFirst { it.name == location.name }
+        if (index >= 0) {
+            dataSet[index] = location
+            notifyItemChanged(index)
+        } else {
+            dataSet.add(location)
+            notifyItemInserted(dataSet.size - 1)
+        }
+    }
 }

--- a/app/src/main/java/moe/fuqiuluo/portal/ui/mock/MockFragment.kt
+++ b/app/src/main/java/moe/fuqiuluo/portal/ui/mock/MockFragment.kt
@@ -30,6 +30,7 @@ import moe.fuqiuluo.portal.ext.altitude
 import moe.fuqiuluo.portal.ext.drawOverOtherAppsEnabled
 import moe.fuqiuluo.portal.ext.historicalLocations
 import moe.fuqiuluo.portal.ext.hookSensor
+import moe.fuqiuluo.portal.ext.jsonHistoricalLocations
 import moe.fuqiuluo.portal.ext.needOpenSELinux
 import moe.fuqiuluo.portal.ext.rawHistoricalLocations
 import moe.fuqiuluo.portal.ext.selectLocation
@@ -196,9 +197,10 @@ class MockFragment : Fragment() {
                         .setMessage("确定要删除位置(${location.name})吗？")
                         .setPositiveButton("删除") { _, _ ->
                             historicalLocationAdapter.removeItem(position)
-                            rawHistoricalLocations = rawHistoricalLocations.toMutableSet().apply {
-                                removeIf { it.split(",")[0] == location.name }
-                            }
+                            // Use JSON storage to handle location deletion
+                            val currentLocations = historicalLocations.toMutableList()
+                            currentLocations.removeIf { it.name == location.name && it.lat == location.lat && it.lon == location.lon }
+                            jsonHistoricalLocations = currentLocations
                             showToast("已删除位置")
                         }
                         .setNegativeButton("取消", { _, _ ->


### PR DESCRIPTION
此 PR 将 HistoricalLocation 部分重构，抛弃了 CSV 存储方式，改为 JSON 。
同时增加了迁移步骤，以兼容旧数据。

## 重构原因
JSON 可直接利用项目中已导入的 com.alibaba.fastjson2 进行处理，不需要增加额外的依赖。
CSV 要完整处理，需要大量的编码实现，可行但是代码可读性和效率会下降。
CSV 即使处理后，Kotlin 字面量也仍然需要对引号转义，否则会出现把 `"123456"` 显示为 `123456` 之类的问题。

## 测试
- [ ] 数据迁移功能